### PR TITLE
FIX: Ajuste API de integração venda pagamento modelo 55

### DIFF
--- a/api/service-layer/vendas/jobs/venda-nfce-para-nfe-pagamentos-integracao.xsjs
+++ b/api/service-layer/vendas/jobs/venda-nfce-para-nfe-pagamentos-integracao.xsjs
@@ -251,7 +251,7 @@ function excutePagamentoNaoIntegrado(byId) {
                 "ProjectCode": "PDV_SOFTQUALITY",
                 "PayToCode": 'Pagamento',
                 "Remarks": 'INTEGRACAO QUALITY PAGAMENTO',
-                "U_IS_ID_QUALITY": byId,
+                "U_IS_ID_QUALITY": registro.IDVENDA,
                 "PaymentType": 'bopt_None',
                 "DocTypte": 'rCustomer',
                 "BPLID": parseInt(registro.IDEMPRESA),


### PR DESCRIPTION
A API não estava preenchendo o campo idvenda no SAP (Contas a receber) quando a mesma era iniciada em lote, portanto, foi realizado o ajuste.