### PR TITLE
Fix: Util label-printer-service

### DIFF
--- a/js/utils/label-printer-service.js
+++ b/js/utils/label-printer-service.js
@@ -3,7 +3,7 @@ async function enviarZPLParaImpressora(labelPagesZPL) {
     return msgWarning('Nenhum arquivo enviado para impressão, verifique e tente novamente!');
   }
 
-  labelPagesZPL = labelPagesZPL.replace(/^[ \t]+/gm, '').replace(/^\s*$/gm, '');
+  labelPagesZPL = labelPagesZPL.replace(/^[ \t]+/gm, '').replace(/^\s*$(?:\r\n?|\n)/gm, '');
 
   animationLoadingStart('Conectando a Impressora, aguarde...', false);
 


### PR DESCRIPTION
Adicionado um Regex para retirada de espaços e linhas em branco no arquivo ZPL enviado pelo front, pois estavam causando travamento das impressoras.